### PR TITLE
Modify the loading method

### DIFF
--- a/src/evaluate_sol.jl
+++ b/src/evaluate_sol.jl
@@ -16,8 +16,6 @@ from src.dgl.get_graph import get_knn_graph
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model = Transformer(in_dim=4, latent_dim=128, n_layers=4).to(device)
-# state_dict = torch.load($py_dir+'weights/model_step4.pt',
-#                         map_location=torch.device(device))
 state_dict = torch.load(os.path.join($py_dir, 'weights', 'model_step4.pt'),
                         map_location=torch.device(device))
 model.load_state_dict(state_dict)

--- a/src/evaluate_sol.jl
+++ b/src/evaluate_sol.jl
@@ -16,7 +16,9 @@ from src.dgl.get_graph import get_knn_graph
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 model = Transformer(in_dim=4, latent_dim=128, n_layers=4).to(device)
-state_dict = torch.load($py_dir+'weights/model_step4.pt', 
+# state_dict = torch.load($py_dir+'weights/model_step4.pt',
+#                         map_location=torch.device(device))
+state_dict = torch.load(os.path.join($py_dir, 'weights', 'model_step4.pt'),
                         map_location=torch.device(device))
 model.load_state_dict(state_dict)
 model.eval()


### PR DESCRIPTION
When running `include("src/main.jl")`, a `ModuleNotFoundError("no module named 'src'")` occurred. Therefore, to resolve this, I propose modifying the definition of `state_dict` in a way that will prevent errors on Windows, macOS, and Linux systems.

Thank you.